### PR TITLE
display list item names

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,8 +7,8 @@ export function List({ data }) {
 				Hello from the <code>/list</code> page!
 			</p>
 			<ul>
-				{data.map((item) => (
-					<ListItem name={item.name} />
+				{data.map((item, index) => (
+					<ListItem key={index} name={item.name} />
 				))}
 			</ul>
 		</>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -7,11 +7,9 @@ export function List({ data }) {
 				Hello from the <code>/list</code> page!
 			</p>
 			<ul>
-				{/**
-				 * TODO: write some JavaScript that renders the `data` array
-				 * using the `ListItem` component that's imported at the top
-				 * of this file.
-				 */}
+				{data.map((item) => (
+					<ListItem name={item.name} />
+				))}
 			</ul>
 		</>
 	);


### PR DESCRIPTION
Co-authored-by: jtooba70@gmail.com


## Description

Adds the names of the list items to the /list page.

## Related Issue

Closes #1.

## Acceptance Criteria

 - The streamListItems function is used in App.jsx to get the items in the current list from the Firestore database
 - The list is passed into the List component as a prop named data
 - In List.jsx, the ListItem component is used to render the name of each item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![List Page before change](https://user-images.githubusercontent.com/5794319/230304033-0bc4594e-4d98-49dd-bd91-455f23f027c1.png)


### After

![List Page after change](https://user-images.githubusercontent.com/5794319/230304168-9cec05dd-6d74-43f2-a3c1-00baca36936b.png)

## Testing Steps / QA Criteria

View the /list page and see the list item names.
