### PR TITLE
Allow users to create new lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.0.0",
 				"firebase": "^9.17.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3660,6 +3661,11 @@
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
 			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.0.0.tgz",
+			"integrity": "sha512-VHw1bfEoqroRpzle5PJLAqfsouhdFudihtRYVZcFbsPv/LVtAWcyEHXDjp1F/ixkXxY/+qyAjaT7XixsqiWOIQ=="
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.0.0",
 		"firebase": "^9.17.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ export function App() {
 			/** Finally, we update our React state. */
 			setData(nextData);
 		});
-	}, [listToken, setListToken]);
+	}, [listToken]);
 
 	return (
 		<Router>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,9 +36,7 @@ export function App() {
 	}
 
 	useEffect(() => {
-		if (!listToken) {
-			localStorage.setItem('listToken', JSON.stringify(listToken));
-		}
+		if (!listToken) return;
 		/**
 		 * streamListItems` takes a `listToken` so it can commuinicate
 		 * with our database, then calls a callback function with
@@ -64,7 +62,7 @@ export function App() {
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home onClick={newToken} />} />
+					<Route index element={<Home newToken={newToken} />} />
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,24 +7,13 @@ import { getItemData, streamListItems } from './api';
 import { useStateWithStorage } from './utils';
 import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
-/*
-->We need to allow users to start new lists, so they can save the things they need to buy. We need to generate a unique token, save it to localstorage and show the list view to the user.
-->For the users already having a token will automatically redirect to the list view.
-->For the users not having a token, a button in the home component will allow them to create a new list by generating a token and saving it to localstorage along with redirecting to the list view.
-*/
-
 export function App() {
 	const [data, setData] = useState([]);
 
 	/**
 	 * Here, we're using a custom hook to create `listToken` and a function
 	 * that can be used to update `listToken` later.
-	 *
-	 * `listToken` is `my test list` by default so you can see the list
-	 * of items that was prepopulated for this project.
-	 * You'll later set it to `null` by default (since new users do not
-	 * have tokens), and use `setListToken` when you allow a user
-	 * to create and join a new list.
+	 * This hook handles saving to and retrieving from localStorage.
 	 */
 	const [listToken, setListToken] = useStateWithStorage(
 		null,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,12 +31,16 @@ export function App() {
 		'tcl-shopping-list-token',
 	);
 
-	function newToken() {
+	function setNewToken() {
 		setListToken(generateToken());
 	}
 
 	useEffect(() => {
-		if (!listToken) return;
+		if (!listToken) {
+			const tokenFromStorage = localStorage.getItem('tcl-shopping-list-token');
+			if (tokenFromStorage) setListToken(tokenFromStorage);
+			else return;
+		}
 		/**
 		 * streamListItems` takes a `listToken` so it can commuinicate
 		 * with our database, then calls a callback function with
@@ -56,13 +60,16 @@ export function App() {
 			/** Finally, we update our React state. */
 			setData(nextData);
 		});
-	}, [listToken]);
+	}, [listToken, setListToken]);
 
 	return (
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home newToken={newToken} />} />
+					<Route
+						index
+						element={<Home setNewToken={setNewToken} token={listToken} />}
+					/>
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { AddItem, Home, Layout, List } from './views';
 
 import { getItemData, streamListItems } from './api';
 import { useStateWithStorage } from './utils';
+import { generateToken } from '@the-collab-lab/shopping-list-utils';
 
 /*
 ->We need to allow users to start new lists, so they can save the things they need to buy. We need to generate a unique token, save it to localstorage and show the list view to the user.
@@ -14,6 +15,7 @@ import { useStateWithStorage } from './utils';
 
 export function App() {
 	const [data, setData] = useState([]);
+
 	/**
 	 * Here, we're using a custom hook to create `listToken` and a function
 	 * that can be used to update `listToken` later.
@@ -24,10 +26,11 @@ export function App() {
 	 * have tokens), and use `setListToken` when you allow a user
 	 * to create and join a new list.
 	 */
-	const [listToken, setListToken] = useStateWithStorage(
-		'my test list',
-		'tcl-shopping-list-token',
-	);
+	const [listToken, setListToken] = useStateWithStorage(null);
+
+	function newToken() {
+		setListToken(generateToken());
+	}
 
 	useEffect(() => {
 		if (!listToken) return;
@@ -57,7 +60,7 @@ export function App() {
 		<Router>
 			<Routes>
 				<Route path="/" element={<Layout />}>
-					<Route index element={<Home />} />
+					<Route index element={<Home onClick={newToken} />} />
 					<Route path="/list" element={<List data={data} />} />
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,10 @@ export function App() {
 	 * have tokens), and use `setListToken` when you allow a user
 	 * to create and join a new list.
 	 */
-	const [listToken, setListToken] = useStateWithStorage(null);
+	const [listToken, setListToken] = useStateWithStorage(
+		null,
+		'tcl-shopping-list-token',
+	);
 
 	function newToken() {
 		setListToken(generateToken());

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,11 +36,7 @@ export function App() {
 	}
 
 	useEffect(() => {
-		if (!listToken) {
-			const tokenFromStorage = localStorage.getItem('tcl-shopping-list-token');
-			if (tokenFromStorage) setListToken(tokenFromStorage);
-			else return;
-		}
+		if (!listToken) return;
 		/**
 		 * streamListItems` takes a `listToken` so it can commuinicate
 		 * with our database, then calls a callback function with

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,8 +36,9 @@ export function App() {
 	}
 
 	useEffect(() => {
-		if (!listToken) return;
-
+		if (!listToken) {
+			localStorage.setItem('listToken', JSON.stringify(listToken));
+		}
 		/**
 		 * streamListItems` takes a `listToken` so it can commuinicate
 		 * with our database, then calls a callback function with

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,12 @@ import { AddItem, Home, Layout, List } from './views';
 import { getItemData, streamListItems } from './api';
 import { useStateWithStorage } from './utils';
 
+/*
+->We need to allow users to start new lists, so they can save the things they need to buy. We need to generate a unique token, save it to localstorage and show the list view to the user.
+->For the users already having a token will automatically redirect to the list view.
+->For the users not having a token, a button in the home component will allow them to create a new list by generating a token and saving it to localstorage along with redirecting to the list view.
+*/
+
 export function App() {
 	const [data, setData] = useState([]);
 	/**

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,12 +1,20 @@
 import './Home.css';
+import { useNavigate } from 'react-router-dom';
 
-export function Home({ onClick }) {
+export function Home({ newToken }) {
+	const navigate = useNavigate();
+	const tokenFromStorage = localStorage.getItem('tcl-shopping-list-token');
+	function handleClick() {
+		newToken();
+		navigate('/list');
+	}
+	if (tokenFromStorage) navigate('/list');
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
-			<button onClick={onClick}>New List</button>
+			<button onClick={handleClick}>New List</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,11 +1,12 @@
 import './Home.css';
 
-export function Home() {
+export function Home({ onClick }) {
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
+			<button onClick={onClick}>New List</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,20 +1,19 @@
 import './Home.css';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
-export function Home({ newToken }) {
+export function Home({ setNewToken, token }) {
 	const navigate = useNavigate();
-	const tokenFromStorage = localStorage.getItem('tcl-shopping-list-token');
-	function handleClick() {
-		newToken();
-		navigate('/list');
-	}
-	if (tokenFromStorage) navigate('/list');
+	useEffect(() => {
+		if (token) navigate('/list');
+	}, [token, navigate]);
+
 	return (
 		<div className="Home">
 			<p>
 				Hello from the home (<code>/</code>) page!
 			</p>
-			<button onClick={handleClick}>New List</button>
+			<button onClick={setNewToken}>New List</button>
 		</div>
 	);
 }

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -7,7 +7,9 @@ export function Home({ setNewToken, token }) {
 	// useEffect will watch for changes to the token and will redirect whenever it exists
 	useEffect(() => {
 		if (token) navigate('/list');
-	}, [token, navigate]);
+		// disable warning that navigate should be a dependency
+		// eslint-disable-next-line
+	}, [token]);
 
 	return (
 		<div className="Home">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 
 export function Home({ setNewToken, token }) {
 	const navigate = useNavigate();
+	// useEffect will watch for changes to the token and will redirect whenever it exists
 	useEffect(() => {
 		if (token) navigate('/list');
 	}, [token, navigate]);


### PR DESCRIPTION
## Description

This change allows users to create their own list with a unique token. The token is saved to localStorage so users have persistent access to their list. (The list token is used as a collection name in Firebase, representing the user's list, so when items are added with a token, they are added to a collection that is only accessible via that token. This does mean that if a user clears their localStorage, they will lose access to their list.)

If a token is not set, the user is shown a "New List" button on the Home view. When clicked, a new token is generated and saved to localStorage, and then the user is redirected to the List view.

If a token is already set, the user is redirected to the List view directly.

## Related Issue

Closes #3 

## Acceptance Criteria

- @the-collab-lab/shopping-list-utils is added as a dependency to the project.
- The string my test list in App.jsx is replaced with null, so users are not automatically subscribed to any list.

### If a user doesn’t already have a token:
- A button in the Home component allows them to create a new list
- Clicking the button generates a new token and saves it to localStorage using the setListToken function in App.jsx.
- Once the token has been created and saved, the user is redirected to the List view.

### If a user does already have a token:
- They are automatically redirected to the List view.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![Home page before changes](https://user-images.githubusercontent.com/5794319/230759887-b4e0f06e-1860-4652-9cfe-4b2036e80e67.png)


### After

![Home page after changes (New List button)](https://user-images.githubusercontent.com/5794319/231421463-c084aea1-5c84-4c88-a336-6d8bd3cb5337.png)


![List page after changes (token set, automatically redirected from home)](https://user-images.githubusercontent.com/5794319/231421394-26b0afe8-69ca-4383-ba28-1eb378cddfe6.png)

## Testing Steps / QA Criteria

When accessing the homepage with no token set, the user will see a "New List" button. After clicking the button, a token will be saved to localStorage (this can be seen in Dev Tools) and the user will be redirected to the /list page. If the user then attempts to visit the homepage, they will find they are automatically redirected back to the /list page.

If the token is cleared from localStorage, then the homepage will once again display the "New List" button.
