### PR TITLE
Add welcoming prompt

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,9 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export function List({ data, token }) {
+	const navigate = useNavigate();
 	const [query, setQuery] = useState('');
 	const handleChange = (event) => {
 		setQuery(event.target.value);
@@ -11,27 +13,41 @@ export function List({ data, token }) {
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
-			{/* welcome message */}
-			<div>
-				<label htmlFor="query">Filter your list</label>
-				<input id="query" value={query} onChange={handleChange} name="query" />
-				{query ? <button onClick={() => setQuery('')}>Clear</button> : null}
-			</div>
-			<ul>
-				{data
-					.filter((item) =>
-						item.name.toLowerCase().includes(query.toLowerCase()),
-					)
-					.map((item) => (
-						<ListItem key={item.id} name={item.name} />
-					))}
-			</ul>
-			<div>
-				<p>
-					Use the token <em style={{ textDecoration: 'underline' }}>{token}</em>{' '}
-					to share your shopping list
-				</p>
-			</div>
+			{!data.length ? (
+				<div>
+					<p>Your list is empty click the add item button to start your list</p>
+					<button onClick={() => navigate('/add-item')}>Add Item</button>
+				</div>
+			) : (
+				<>
+					<div>
+						<label htmlFor="query">Filter your list</label>
+						<input
+							id="query"
+							value={query}
+							onChange={handleChange}
+							name="query"
+						/>
+						{query ? <button onClick={() => setQuery('')}>Clear</button> : null}
+					</div>
+					<ul>
+						{data
+							.filter((item) =>
+								item.name.toLowerCase().includes(query.toLowerCase()),
+							)
+							.map((item) => (
+								<ListItem key={item.id} name={item.name} />
+							))}
+					</ul>
+					<div>
+						<p>
+							Use the token{' '}
+							<em style={{ textDecoration: 'underline' }}>{token}</em> to share
+							your shopping list
+						</p>
+					</div>
+				</>
+			)}
 		</>
 	);
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -11,6 +11,7 @@ export function List({ data, token }) {
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
+			{/* welcome message */}
 			<div>
 				<label htmlFor="query">Filter your list</label>
 				<input id="query" value={query} onChange={handleChange} name="query" />

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -13,7 +13,7 @@ export function List({ data, token }) {
 			<p>
 				Hello from the <code>/list</code> page!
 			</p>
-			{!data.length ? (
+			{!data?.length ? (
 				<div>
 					<p>
 						Your list is empty. Click the add item button to start your list.

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -15,7 +15,9 @@ export function List({ data, token }) {
 			</p>
 			{!data.length ? (
 				<div>
-					<p>Your list is empty click the add item button to start your list</p>
+					<p>
+						Your list is empty. Click the add item button to start your list.
+					</p>
 					<button onClick={() => navigate('/add-item')}>Add Item</button>
 				</div>
 			) : (


### PR DESCRIPTION
Co-authored-by: l.abrocadabro@gmail.com

## Description

This change adds a welcoming prompt on the List page. If the user goes to the List page with no list token saved in local storage, an Add item button is displayed on the screen. Clicking on the Add item button takes the user to the `add-item` page.

## Related Issue

Closes #7  

## Acceptance Criteria

- [x] The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

https://user-images.githubusercontent.com/52610124/234607427-9a662709-7ca9-49ab-99d4-4126d75d233e.mp4

### After

https://user-images.githubusercontent.com/52610124/234607607-c466f569-8545-4dfb-bd6c-623add5b3a68.mp4

## Testing Steps / QA Criteria

1. Run `git checkout tj-la-new-list-welcome-message`
2. Run `npm start`
3. Verify if the List page shows an Add item button which takes you to the `add-item` page when there is no saved list in your browser