### PR TITLE
Redirect and hide links if no list token exists

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ export function App() {
 	return (
 		<Router>
 			<Routes>
-				<Route path="/" element={<Layout />}>
+				<Route path="/" element={<Layout token={listToken} />}>
 					<Route
 						index
 						element={

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,7 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { addItem } from '../api/firebase';
+import { useNavigate } from 'react-router-dom';
 
 export function AddItem({ data, token }) {
+	const navigate = useNavigate();
+	useEffect(() => {
+		if (!token) navigate('/');
+		// disable warning that navigate should be a dependency
+		// eslint-disable-next-line
+	}, [token]);
 	const [formData, setFormData] = useState({
 		itemName: '',
 		daysUntilNextPurchase: '',
@@ -62,12 +69,9 @@ export function AddItem({ data, token }) {
 
 		setTimeout(() => setShowMessage(false), 3000);
 	}
-
+	if (!token) return <p></p>;
 	return (
 		<>
-			<p>
-				Hello from the <code>/add-item</code> page!
-			</p>
 			<form onSubmit={handleSubmit}>
 				<label htmlFor="itemName">Item name:</label>
 				<br />

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -34,7 +34,7 @@ export function Home({ setNewToken, token, setToken }) {
 			});
 		setExistingToken('');
 	}
-
+	if (token) return <p></p>;
 	return (
 		<div className="Home">
 			<p>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -2,7 +2,7 @@ import { Outlet, NavLink } from 'react-router-dom';
 
 import './Layout.css';
 
-export function Layout() {
+export function Layout({ token }) {
 	return (
 		<>
 			<div className="Layout">
@@ -16,12 +16,16 @@ export function Layout() {
 					<NavLink to="/" className="Nav-link">
 						Home
 					</NavLink>
-					<NavLink to="/list" className="Nav-link">
-						List
-					</NavLink>
-					<NavLink to="/add-item" className="Nav-link">
-						Add Item
-					</NavLink>
+					{token ? (
+						<>
+							<NavLink to="/list" className="Nav-link">
+								List
+							</NavLink>
+							<NavLink to="/add-item" className="Nav-link">
+								Add Item
+							</NavLink>
+						</>
+					) : null}
 				</nav>
 			</div>
 		</>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,18 +1,21 @@
 import { ListItem } from '../components';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function List({ data, token }) {
 	const navigate = useNavigate();
+	useEffect(() => {
+		if (!token) navigate('/');
+		// disable warning that navigate should be a dependency
+		// eslint-disable-next-line
+	}, [token]);
 	const [query, setQuery] = useState('');
 	const handleChange = (event) => {
 		setQuery(event.target.value);
 	};
+	if (!token) return <p></p>;
 	return (
 		<>
-			<p>
-				Hello from the <code>/list</code> page!
-			</p>
 			{!data?.length ? (
 				<div>
 					<p>


### PR DESCRIPTION
## Description

This PR deals with the long-standing issue we've discussed, that if a user accesses the list or add item page when no token is set, they still see those pages. 

I also dealt with the related issue of having flashes of content from other pages before the redirect. Now, when the token does exist on the homepage, or a token doesn't exist on the list/add item pages, a blank paragraph tag is rendered, which prevents anything from displaying before the redirect.

There is one small remaining issue that needs to be discussed, which is what we should do about the home page link when a list token is set. We can either hide the home page and leave it at that, or modify the app so that users can return to the homepage and enter a different token in order to switch lists. 


## Acceptance Criteria

There is no related issue, but the acceptance criteria that were discussed were:
1. If no list token exists and a user tries to access the /iist or /add-item page, they are redirected back to the homepage.
2. Hide the links to the list and add item pages while no token exists (only home page is visible.


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![Navigation links visible when creating new list](https://user-images.githubusercontent.com/5794319/236379583-4a855972-96a6-4bce-82a7-3bff85b7d05e.png)

### After
![Navigation links hidden when creating new list](https://user-images.githubusercontent.com/5794319/236379643-a20f30ce-c234-4950-9980-571c6cb9bc56.png)

https://user-images.githubusercontent.com/5794319/236379679-f4640838-af57-4aca-b692-f2fe4bdc907a.mov


## Testing Steps / QA Criteria

Visit the homepage with no token set and try to access the list or add item pages, you will be redirected back to home. Try to visit the home page when the list token is set, you will be redirected back to the list page. No flashes of content from the origin pages will be visible.
