### PR TITLE
Add global styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
 			name="description"
 			content="A smart shopping list that learns your purchase habits and makes suggestions, so you don't forget to buy what's important."
 		/>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap"
+			rel="stylesheet"
+		/>
 		<link rel="icon" type="image/svg+xml" href="/src/favicon.ico" />
 		<meta name="color-scheme" content="dark light" />
 		<title>Smart Shopping List</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 				"firebase": "^9.17.2",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
+				"react-icons": "^4.8.0",
 				"react-modal": "^3.16.1",
 				"react-router-dom": "^6.9.0"
 			},
@@ -8683,6 +8684,14 @@
 			},
 			"peerDependencies": {
 				"react": "^18.2.0"
+			}
+		},
+		"node_modules/react-icons": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+			"integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+			"peerDependencies": {
+				"react": "*"
 			}
 		},
 		"node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"firebase": "^9.17.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"react-icons": "^4.8.0",
 		"react-modal": "^3.16.1",
 		"react-router-dom": "^6.9.0"
 	},

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -6,7 +6,7 @@
 }
 
 .ListItem-checkbox {
-	accent-color: var(--color-accent);
+	accent-color: var(--color-accent-primary);
 }
 
 .ListItem-label {

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,6 @@
 	--color-bg: var(--color-med-brown);
 	--color-text: var(--color-xdark-green);
 	--color-accent: var(--color-dark-brown);
-	--color-text-alt: var(--color-dark-green);
 }
 
 @media screen and (prefers-color-scheme: light) {
@@ -18,7 +17,6 @@
 		--color-bg: var(--color-med-brown);
 		--color-text: var(--color-xdark-green);
 		--color-accent: var(--color-dark-brown);
-		--color-text-alt: var(--color-dark-green);
 	}
 }
 
@@ -26,7 +24,6 @@
 	--color-bg: var(--color-med-brown);
 	--color-text: var(--color-xdark-green);
 	--color-accent: var(--color-dark-brown);
-	--color-text-alt: var(--color-dark-green);
 }
 
 *,

--- a/src/index.css
+++ b/src/index.css
@@ -1,35 +1,32 @@
 :root {
-	--color-black: hsla(220, 13%, 18%, 1);
-	--color-gray-dark: hsla(220, 13%, 25%, 1);
-	--color-white: hsla(220, 13%, 98%, 1);
-	--color-gray-light: hsla(220, 13%, 94%, 1);
-	--color-emerald-green: hsla(168, 92%, 25%, 1);
-	--color-vermillion-green: hsla(168, 92%, 43%, 1);
-	--color-cobalt-blue: hsla(215, 100%, 34%, 1);
-	--color-pastel-blue: hsla(215, 100%, 73%, 1);
-	--color-red: hsl(0, 68%, 42%);
+	--color-xdark-green: #11310d;
+	--color-dark-green: #1e5b18;
+	--color-med-green: #ccd5ae;
+	--color-light-green: #e9edc9;
+	--color-dark-brown: #c9b29b;
+	--color-med-brown: #f2e8ce;
+	--color-light-brown: #fefae0;
 
-	--color-accent: var(--color-pastel-blue);
-	--color-bg: var(--color-black);
-	--color-bg-well: var(--color-gray-dark);
-	--color-error: var(--color-red);
-	--color-text: var(--color-white);
+	--color-bg: var(--color-med-brown);
+	--color-text: var(--color-xdark-green);
+	--color-accent: var(--color-dark-brown);
+	--color-text-alt: var(--color-dark-green);
 }
 
 @media screen and (prefers-color-scheme: light) {
 	:root {
-		--color-accent: var(--color-cobalt-blue);
-		--color-bg: var(--color-white);
-		--color-bg-well: var(--color-gray-light);
-		--color-text: var(--color-black);
+		--color-bg: var(--color-med-brown);
+		--color-text: var(--color-xdark-green);
+		--color-accent: var(--color-dark-brown);
+		--color-text-alt: var(--color-dark-green);
 	}
 }
 
 :root.theme-light {
-	--color-accent: var(--color-cobalt-blue);
-	--color-bg: var(--color-white);
-	--color-bg-well: var(--color-gray-light);
-	--color-text: var(--color-black);
+	--color-bg: var(--color-med-brown);
+	--color-text: var(--color-xdark-green);
+	--color-accent: var(--color-dark-brown);
+	--color-text-alt: var(--color-dark-green);
 }
 
 *,
@@ -55,38 +52,13 @@ html {
 body {
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,
-		helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+	font-family: Poppins, arial, sans-serif;
 	font-size: 1.6rem;
 	line-height: 1.4;
 	margin: 0;
 
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-}
-
-code {
-	--color-bg: var(--color-gray-dark);
-	--color-text: var(--color-accent);
-
-	background-color: var(--color-bg);
-	border-radius: 4px;
-	color: var(--color-text);
-	display: inline-block;
-	font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
-		monospace;
-	font-size: 0.9em;
-	padding: 0.15em 0.15em;
-}
-
-@media screen and (prefers-color-scheme: light) {
-	code {
-		--color-bg: var(--color-gray-light);
-	}
-}
-
-:root.theme-light code {
-	--color-bg: var(--color-gray-light);
 }
 
 ul {

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,7 @@ input[type='text'] {
 	font-size: 1.6rem;
 	padding: 0.5rem 0.8rem;
 	background-color: var(--color-accent-primary-alt);
+	color: var(--color-text);
 }
 
 input[type='text']:focus,

--- a/src/index.css
+++ b/src/index.css
@@ -1,29 +1,37 @@
 :root {
-	--color-xdark-green: #11310d;
-	--color-dark-green: #1e5b18;
-	--color-med-green: #ccd5ae;
+	--color-dark-green: #11310d;
+	--color-med-green: #1e5b18;
 	--color-light-green: #eef1d8;
 	--color-dark-brown: #c9b29b;
 	--color-med-brown: #f2e8ce;
 	--color-light-brown: #fefae0;
 
 	--color-bg: var(--color-med-brown);
-	--color-text: var(--color-xdark-green);
-	--color-accent: var(--color-dark-brown);
+	--color-text: var(--color-dark-green);
+	--color-accent-primary: var(--color-dark-brown);
+	--color-accent-primary-alt: var(--color-light-brown);
+	--color-accent-secondary: var(--color-med-green);
+	--color-accent-secondary-alt: var(--color-light-green);
 }
 
 @media screen and (prefers-color-scheme: light) {
 	:root {
 		--color-bg: var(--color-med-brown);
-		--color-text: var(--color-xdark-green);
-		--color-accent: var(--color-dark-brown);
+		--color-text: var(--color-dark-green);
+		--color-accent-primary: var(--color-dark-brown);
+		--color-accent-primary-alt: var(--color-light-brown);
+		--color-accent-secondary: var(--color-med-green);
+		--color-accent-secondary-alt: var(--color-light-green);
 	}
 }
 
 :root.theme-light {
 	--color-bg: var(--color-med-brown);
-	--color-text: var(--color-xdark-green);
-	--color-accent: var(--color-dark-brown);
+	--color-text: var(--color-dark-green);
+	--color-accent-primary: var(--color-dark-brown);
+	--color-accent-primary-alt: var(--color-light-brown);
+	--color-accent-secondary: var(--color-med-green);
+	--color-accent-secondary-alt: var(--color-light-green);
 }
 
 *,
@@ -62,8 +70,8 @@ ul {
 	padding: 0;
 }
 button {
-	background-color: var(--color-dark-green);
-	color: var(--color-light-brown);
+	background-color: var(--color-accent-secondary);
+	color: var(--color-accent-primary-alt);
 	padding: 0.8rem 1.5rem;
 	border: 2px solid transparent;
 	border-radius: 7px;
@@ -74,23 +82,23 @@ button {
 }
 button:hover,
 button:active {
-	background-color: var(--color-xdark-green);
+	background-color: var(--color-text);
 }
 
 button:focus-visible {
 	background-color: var(--color-light-green);
-	color: var(--color-xdark-green);
-	border: 2px solid var(--color-xdark-green);
+	color: var(--color-text);
+	border: 2px solid var(--color-text);
 	font-weight: bold;
 }
 
 input[type='text'] {
-	border: 2px solid var(--color-accent);
+	border: 2px solid var(--color-accent-primary);
 	border-radius: 7px;
 	outline: none;
 	font-size: 1.6rem;
 	padding: 0.5rem 0.8rem;
-	background-color: var(--color-light-brown);
+	background-color: var(--color-accent-primary-alt);
 }
 
 input[type='text']:focus,

--- a/src/index.css
+++ b/src/index.css
@@ -64,3 +64,20 @@ body {
 ul {
 	padding: 0;
 }
+button {
+	background-color: var(--color-dark-green);
+	color: var(--color-light-brown);
+	padding: 0.8rem 1.5rem;
+	border: none;
+	border-radius: 7px;
+	font-size: 1.5rem;
+	letter-spacing: 0.1rem;
+	text-transform: uppercase;
+	outline: none;
+}
+button:hover,
+button:active,
+button:focus {
+	background-color: var(--color-xdark-green);
+	box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.25);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 	--color-xdark-green: #11310d;
 	--color-dark-green: #1e5b18;
 	--color-med-green: #ccd5ae;
-	--color-light-green: #e9edc9;
+	--color-light-green: #eef1d8;
 	--color-dark-brown: #c9b29b;
 	--color-med-brown: #f2e8ce;
 	--color-light-brown: #fefae0;
@@ -80,4 +80,19 @@ button:active,
 button:focus {
 	background-color: var(--color-xdark-green);
 	box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.25);
+}
+
+input[type='text'] {
+	border: 2px solid var(--color-accent);
+	border-radius: 7px;
+	outline: none;
+	font-size: 1.6rem;
+	padding: 0.5rem 0.8rem;
+	background-color: var(--color-light-brown);
+}
+
+input[type='text']:focus,
+input[type='text']:active {
+	border: 2px solid var(--color-text);
+	background-color: var(--color-light-green);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,7 @@ button {
 button:hover,
 button:active {
 	background-color: var(--color-text);
+	cursor: pointer;
 }
 
 button:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -68,7 +68,7 @@ button {
 	background-color: var(--color-dark-green);
 	color: var(--color-light-brown);
 	padding: 0.8rem 1.5rem;
-	border: none;
+	border: 2px solid transparent;
 	border-radius: 7px;
 	font-size: 1.5rem;
 	letter-spacing: 0.1rem;
@@ -76,10 +76,15 @@ button {
 	outline: none;
 }
 button:hover,
-button:active,
-button:focus {
+button:active {
 	background-color: var(--color-xdark-green);
-	box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.25);
+}
+
+button:focus-visible {
+	background-color: var(--color-light-green);
+	color: var(--color-xdark-green);
+	border: 2px solid var(--color-xdark-green);
+	font-weight: bold;
 }
 
 input[type='text'] {

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -37,9 +37,6 @@ export function Home({ setNewToken, token, setToken }) {
 	if (token) return <p></p>;
 	return (
 		<div className="Home">
-			<p>
-				Hello from the home (<code>/</code>) page!
-			</p>
 			<button onClick={setNewToken}>New List</button>
 			<form onSubmit={handleSubmit}>
 				<label htmlFor="existingToken">Enter existing token:</label>

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -10,53 +10,48 @@
 .Layout {
 	display: flex;
 	flex-direction: column;
-	margin: 0 auto;
-	max-width: 100vw;
-	padding-top: calc(1rem + env(safe-area-inset-top, 1rem));
-	padding-bottom: calc(1rem + env(safe-area-inset-bottom, 1rem));
-	width: 54rem;
 }
 
 .Layout-header {
-	background-color: var(--color-bg);
+	background-color: var(--color-accent);
 	position: sticky;
 	text-align: center;
 	top: 0;
 }
-
-.Layout-header > h1 {
-	margin-top: 0;
+.Layout-header h1 {
+	color: var(--color-text);
+	margin: 1rem 0;
 }
 
 .Layout-main {
 	margin: 0 auto;
-	max-width: 95vw;
-	width: 95%;
+	max-width: 100vw;
+	padding-top: calc(2vh + env(safe-area-inset-top, 1rem));
+	padding-bottom: calc(2vh + env(safe-area-inset-bottom, 1rem));
+	width: 54rem;
 }
 
 .Nav {
 	align-items: stretch;
-	background-color: var(--color-bg);
+	background-color: var(--color-accent);
 	bottom: 0;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-around;
 	margin-top: auto;
 	position: sticky;
+	padding: 1rem;
 }
 
 .Nav-link {
-	--color-text: var(--color-accent);
-
 	color: var(--color-text);
 	font-size: 1.45em;
 	flex: 0 1 auto;
 	padding: 0.8rem;
 	text-align: center;
-	text-underline-offset: 0.1em;
+	text-decoration: none;
 }
 
 .Nav-link.active {
-	text-decoration-thickness: 0.22em;
-	text-underline-offset: 0.1em;
+	font-weight: bold;
 }

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -13,7 +13,7 @@
 }
 
 .Layout-header {
-	background-color: var(--color-accent);
+	background-color: var(--color-accent-primary);
 	position: sticky;
 	text-align: center;
 	top: 0;
@@ -33,7 +33,7 @@
 
 .Nav {
 	align-items: stretch;
-	background-color: var(--color-accent);
+	background-color: var(--color-accent-primary);
 	bottom: 0;
 	display: flex;
 	flex-direction: row;

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -50,8 +50,12 @@
 	padding: 0.8rem;
 	text-align: center;
 	text-decoration: none;
+	outline: none;
 }
 
 .Nav-link.active {
 	font-weight: bold;
+}
+.Nav-link:focus-visible {
+	text-decoration: underline;
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -30,6 +30,7 @@ export function List({ data, token }) {
 					<div>
 						<label htmlFor="query">Filter your list</label>
 						<input
+							type="text"
 							id="query"
 							value={query}
 							onChange={handleChange}


### PR DESCRIPTION
I'm forgoing the PR template for this one as it's a special case.

1. This PR builds off of the modal PR so that the modal functionality is included and can be styled (the toasts have already been styled). It also prevents merge conflicts with the modal branch.

2. The `la-add-global-styling` branch for this PR sets the global styling for the app, so all further styling should be branched from here. You can do that by switching to this branch before creating your branch.

3. `react-icons` has been added to the package.json, run `npm install` to use it.

4. Note that CSS variables have been set for the color scheme. You will see that there are two sets of variables, one that sets the colors and one that simply assigns those colors to more semantic names.

  ```	
  --color-dark-green: #11310d;
  --color-med-green: #1e5b18;
  --color-light-green: #eef1d8;
  --color-dark-brown: #c9b29b;
  --color-med-brown: #f2e8ce;
  --color-light-brown: #fefae0;
  
  --color-bg: var(--color-med-brown);
  --color-text: var(--color-dark-green);
  --color-accent-primary: var(--color-dark-brown);
  --color-accent-primary-alt: var(--color-light-brown);
  --color-accent-secondary: var(--color-med-green);
  --color-accent-secondary-alt: var(--color-light-green);
  ```
  
  The second set of variables is designed to make support for dark mode easier, as we will be able to simply conditionally set the semantic names to their dark most variants, without altering the styling of individual components.
  
  As such, please use the semantic variables rather than the color variables when writing your CSS. 
